### PR TITLE
Potential fix for code scanning alert no. 1: Incomplete regular expression for hostnames

### DIFF
--- a/google-fonts.mjs
+++ b/google-fonts.mjs
@@ -5,7 +5,7 @@ import { ofetch } from "ofetch";
 import { Hookable } from "hookable";
 import deepmerge from "deepmerge";
 
-const GOOGLE_FONTS_DOMAIN = "fonts.googleapis.com";
+const GOOGLE_FONTS_DOMAIN = "fonts\\.googleapis\\.com";
 function isValidDisplay(display) {
   return ["auto", "block", "swap", "fallback", "optional"].includes(display);
 }


### PR DESCRIPTION
Potential fix for [https://github.com/alexmensch/alxm.me/security/code-scanning/1](https://github.com/alexmensch/alxm.me/security/code-scanning/1)

To fix the problem, we need to ensure that the `GOOGLE_FONTS_DOMAIN` string is correctly escaped when used in a regular expression. This involves replacing the `.` character with `\.` to prevent unintended matches. We will update the definition of `GOOGLE_FONTS_DOMAIN` to use the escaped version.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
