### PR TITLE
Add wrangler as a direct site devDependency (fix az8.6 deploy regression)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ importers:
       stylelint-config-standard-scss:
         specifier: ^17.0.0
         version: 17.0.0(postcss@8.5.15)(stylelint@17.13.0)
+      wrangler:
+        specifier: ^4.98.0
+        version: 4.105.0
 
   sites/alxm.me:
     dependencies:
@@ -244,6 +247,9 @@ importers:
       stylelint-config-standard-scss:
         specifier: ^16.0.0
         version: 16.0.0(postcss@8.5.15)(stylelint@16.26.1)
+      wrangler:
+        specifier: ^4.98.0
+        version: 4.105.0
 
 packages:
 

--- a/sites/alexmarshalltherapy.com/package.json
+++ b/sites/alexmarshalltherapy.com/package.json
@@ -56,6 +56,7 @@
     "prettier": "^3.8.4",
     "sharp": "0.34.5",
     "stylelint": "^17.13.0",
-    "stylelint-config-standard-scss": "^17.0.0"
+    "stylelint-config-standard-scss": "^17.0.0",
+    "wrangler": "^4.98.0"
   }
 }

--- a/sites/alxm.me/package.json
+++ b/sites/alxm.me/package.json
@@ -62,6 +62,7 @@
     "prettier": "^3.8.3",
     "sharp": "0.34.5",
     "stylelint": "^16.26.1",
-    "stylelint-config-standard-scss": "^16.0.0"
+    "stylelint-config-standard-scss": "^16.0.0",
+    "wrangler": "^4.98.0"
   }
 }


### PR DESCRIPTION
## Regression

After #253 (cf-r2-sync extraction), `pnpm alxm:deploy:stg` failed:

```
🚀 R2 sync complete! 0/6 files uploaded
sh: wrangler: command not found
[ELIFECYCLE] Command failed with exit code 1.
```

The R2 sync itself works (0/6 = all unchanged, the `@aws-sdk` path is fine). The failure is the *next* step, `npx wrangler deploy --env=staging`.

## Cause

#253 dissolved each site's nested `_cloudflare/r2` pnpm workspace, whose `cd _cloudflare/r2 && pnpm install` had placed a `wrangler` binary in `_cloudflare/r2/node_modules/.bin`. Each site's `deploy`/`deploy:stg` scripts call `npx wrangler deploy` **at the site level**, but after #253 `wrangler` survived only as a *transitive* dep of `@alxm/cf-r2-sync` (`pnpm why wrangler` → only via cf-r2-sync) and was no longer linked into the site's `node_modules/.bin`.

## Fix

Declare `wrangler` as a direct **devDependency** of both sites — it's the site's own deploy tooling, alongside eslint/prettier/sass. Pinned `^4.98.0` to match `@alxm/cf-r2-sync`; pnpm dedupes to a single `wrangler@4.105.0` in the store.

## Verification

- `npx wrangler --version` → `4.105.0` from **both** `sites/alxm.me/` and `sites/alexmarshalltherapy.com/` (the exact command that errored).
- `wrangler deploy --env=staging --dry-run` bundles the worker, lists the staging bindings (R2_BUCKET, ASSETS, R2_PATHS, RSS_*), and exits cleanly — no auth/upload needed.
- `pnpm check:packages` green; `package.json` files pass Prettier.
- Only one `wrangler` version in the store after the change (deduped).

Closes `alxm_me-72y`.