### PR TITLE
security: markdown-it 14.2.0 override (alxm_me-0fs.1)

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   liquidjs: ^10.26.0
   sharp: 0.34.5
+  markdownlint-cli2>markdown-it: 14.2.0
 
 importers:
 
@@ -2206,10 +2207,6 @@ packages:
 
   markdown-it-smartarrows@1.0.1:
     resolution: {integrity: sha512-LwWnlFyLY5ANjLR0a8BuLvQEm4Ri76IavQwqTnpquSiMoE3JXefk5Pu7nD5VKn784bgLqL3sexdt/j8GwuLgOw==}
-
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
-    hasBin: true
 
   markdown-it@14.2.0:
     resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
@@ -4946,15 +4943,6 @@ snapshots:
 
   markdown-it-smartarrows@1.0.1: {}
 
-  markdown-it@14.1.1:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.1
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
   markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
@@ -4974,7 +4962,7 @@ snapshots:
       js-yaml: 4.1.1
       jsonc-parser: 3.3.1
       jsonpointer: 5.0.1
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
       markdownlint: 0.40.0
       markdownlint-cli2-formatter-default: 0.0.6(markdownlint-cli2@0.22.1)
       micromatch: 4.0.8

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,6 +5,7 @@ packages:
 overrides:
   liquidjs: "^10.26.0"
   sharp: 0.34.5
+  markdownlint-cli2>markdown-it: "14.2.0"
 allowBuilds:
   "@ffprobe-installer/darwin-arm64": true
   "@parcel/watcher": true


### PR DESCRIPTION
## Summary

Closes the **markdown-it** medium Dependabot alert (GHSA-6v5v-wf23-fmfq, vulnerable range `<=14.1.1`, fix `14.2.0`) via a scoped pnpm override. Child A of epic **alxm_me-0fs** (dependency/security maintenance).

The only vulnerable copy was `14.1.1`, pinned **exactly** by `markdownlint-cli2@0.22.1` (dev) — a plain reinstall would not lift it. `eleventy` and `@alxm/eleventy-config` already resolve `14.2.0`. The scoped override `markdownlint-cli2>markdown-it: "14.2.0"` brings the last copy to the security release so the alert auto-resolves.

```diff
 overrides:
   liquidjs: "^10.26.0"
   sharp: 0.34.5
+  markdownlint-cli2>markdown-it: "14.2.0"
```

## js-yaml (separate, no code change)

The other remaining open alert — **js-yaml** (GHSA-h67p-54hq-rp68, merge-key quadratic DoS on **untrusted** YAML) — is **dismissed** as *not affected (trusted input)*: the `3.14.2` copies come via `gray-matter` (build-time front-matter parsing of self-authored content) + `depcheck` (dev) and pin `js-yaml ^3`; reaching `4.2.0` would need a forced major override that risks breaking gray-matter. The vuln never applies to own front-matter, so it's dismissed rather than forced.

## Verification

- `pnpm why markdown-it` → single `14.2.0` (no `14.1.1` remaining). ✅
- `pnpm -C sites/alxm.me lint:md` → 0 errors over 35 files. ✅
- No `.js`/`.scss`/template source changed — `pnpm-workspace.yaml` override + lockfile only. ✅

## Merge note

Per the epic, this and sibling PRs (B/C/D) all touch the root lockfile and should be **merged sequentially with a rebase between each**.