### PR TITLE
fix(amt): repoint package.json URLs to alxm.me monorepo

### DIFF
--- a/sites/alexmarshalltherapy.com/package.json
+++ b/sites/alexmarshalltherapy.com/package.json
@@ -22,14 +22,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/alexmensch/alexmarshalltherapy.com.git"
+    "url": "git+https://github.com/alexmensch/alxm.me.git"
   },
   "author": "Alex Marshall",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/alexmensch/alexmarshalltherapy.com/issues"
+    "url": "https://github.com/alexmensch/alxm.me/issues"
   },
-  "homepage": "https://github.com/alexmensch/alexmarshalltherapy.com#readme",
+  "homepage": "https://github.com/alexmensch/alxm.me#readme",
   "dependencies": {
     "@11ty/eleventy": "^3.1.6",
     "@11ty/eleventy-img": "^6.0.4",


### PR DESCRIPTION
## What

Repoint the three `package.json` metadata URLs in `sites/alexmarshalltherapy.com/` from the standalone `alexmensch/alexmarshalltherapy.com` repo to the `alexmensch/alxm.me` monorepo:

- `repository.url`
- `bugs.url`
- `homepage`

## Why

The standalone `alexmarshalltherapy.com` repo is archived and slated for deletion. Once it's gone, these URLs would 404. This matches the convention already used in the sibling `sites/alxm.me/package.json` (same `alxm.me` URLs, no `directory` field).

## Test plan

Metadata-only change to a non-published package (the site isn't published to npm). No build/runtime impact — these fields are informational. Verified the new URLs match `sites/alxm.me/package.json`.