### PR TITLE
fix(artwork): use CSS Grid Lanes for gallery masonry (alxm_me-lzp)

### DIFF
--- a/sites/alxm.me/src/assets/scss/blocks/_artwork.scss
+++ b/sites/alxm.me/src/assets/scss/blocks/_artwork.scss
@@ -6,9 +6,9 @@
 
     @include compositions.grid;
 
-    // This is not yet widely supported as of Dec/2025
-    // Leaving this in for eventual browser support
-    grid-template-rows: masonry;
+    @supports (display: grid-lanes) {
+      display: grid-lanes;
+    }
   }
 
   &__preview > :is([data-target]) {


### PR DESCRIPTION
## What

The artwork gallery (`/artwork`) carried a stale `grid-template-rows: masonry` placeholder — the original Firefox-prototype masonry syntax. The CSS WG has since converged on **CSS Grid Lanes** (`display: grid-lanes`), which shipped first in Safari 26 (Chrome/Firefox behind flags, expected to ship through 2026).

## Change

`.artwork__gallery` now layers masonry as a progressive enhancement on top of the existing `compositions.grid` baseline:

```scss
.artwork__gallery {
  --min-item-width: 320px;
  @include compositions.grid;
  @supports (display: grid-lanes) {
    display: grid-lanes;
  }
}
```

Grid Lanes reuses the grid's `grid-template-columns`, so only `display` is overridden inside `@supports`. Browsers without support render the exact auto-fit grid they do today — no regression, no JS, no polyfill.

## Acceptance

- [x] Stale `grid-template-rows: masonry` placeholder removed
- [x] Masonry added as a pure-CSS progressive enhancement (`@supports`)
- [x] Baseline auto-fit grid untouched for unsupporting browsers
- [x] `pnpm run build` passes; `pnpm run lint:css` clean

## Verification — needs eyeballs

The masonry packing itself can only be confirmed on a live render in a supporting browser (Safari 26). Per project convention, **smoke on a staging deploy** (`pnpm alxm:deploy:stg`) and eyeball `/artwork`:
- In Safari 26: gallery should pack as masonry (no row-aligned gaps).
- In a non-supporting browser: identical to current production (auto-fit grid).