### PR TITLE
deps: drop prettier minimumReleaseAge exclude — 3.9.1 aged past gate (alxm_me-0fs.5)

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,5 +12,3 @@ allowBuilds:
   esbuild: true
   sharp: true
   workerd: true
-minimumReleaseAgeExclude:
-  - prettier@3.9.1


### PR DESCRIPTION
Follow-up to `0fs.2` / #256. `prettier@3.9.1` was ~1 day old at that merge, so pnpm's default `minimumReleaseAge` gate auto-added it to `minimumReleaseAgeExclude` in `pnpm-workspace.yaml`. It is now ~4 days old (published 2026-06-27) and clears the ~2-day gate normally, so the exclude is dead weight.

## Change

Removed the `minimumReleaseAgeExclude:` block from `pnpm-workspace.yaml`.

## Verification

- `pnpm install` — did **not** re-add the exclude (proves 3.9.1 now passes the age gate); supply-chain policy check passed.
- `pnpm-lock.yaml` **unchanged** — `prettier@3.9.1` still resolves across both sites (`alxm.me`, `alexmarshalltherapy.com`).
- `pnpm lint:packages` — green.

Diff is a single removed block; no code paths touched.